### PR TITLE
Added missing example command to include best-estimate file

### DIFF
--- a/derivative-stats.py
+++ b/derivative-stats.py
@@ -73,6 +73,8 @@ the safety off, throw the overwrite flag:
 not the mean (for example, a free energy curve produced by pooling
 the raw data, then applying wham to that pool) for the purpose
 
+./derivative-stats.py --best-estimate curve-mean.dat curve-1.dat curve-2.dat curve-3.dat curve-i.dat 
+
 	where the curve-i.dat files are placeholders for the files
 containing the FECs. To change the prefix for this file, add the
 prefix flag:

--- a/derivative-stats.py
+++ b/derivative-stats.py
@@ -73,7 +73,7 @@ the safety off, throw the overwrite flag:
 not the mean (for example, a free energy curve produced by pooling
 the raw data, then applying wham to that pool) for the purpose
 
-./derivative-stats.py --best-estimate curve-mean.dat curve-1.dat curve-2.dat curve-3.dat curve-i.dat 
+./derivative-stats.py --best-estimate curve-mean.dat curve-1.dat curve-2.dat curve-3.dat 
 
 	where the curve-i.dat files are placeholders for the files
 containing the FECs. To change the prefix for this file, add the

--- a/fullhelp.txt
+++ b/fullhelp.txt
@@ -18,7 +18,7 @@ If you run this command again you'll find you get an error; this is a safety bui
 
 To use a 'best estimate' for the center of your data that is not the mean (for example, a free energy curve produced by pooling the raw data, then applying wham to that pool) for the purpose 
 
-./derivative-stats.py --best-estimate curve-mean.dat curve-1.dat curve-2.dat curve-3.dat curve-i.dat 
+./derivative-stats.py --best-estimate curve-mean.dat curve-1.dat curve-2.dat curve-3.dat 
 
 where the curve-i.dat files are placeholders for the files containing the FECs. To change the prefix for this file, add the prefix flag:
 

--- a/fullhelp.txt
+++ b/fullhelp.txt
@@ -18,6 +18,8 @@ If you run this command again you'll find you get an error; this is a safety bui
 
 To use a 'best estimate' for the center of your data that is not the mean (for example, a free energy curve produced by pooling the raw data, then applying wham to that pool) for the purpose 
 
+./derivative-stats.py --best-estimate curve-mean.dat curve-1.dat curve-2.dat curve-3.dat curve-i.dat 
+
 where the curve-i.dat files are placeholders for the files containing the FECs. To change the prefix for this file, add the prefix flag:
 
 ./derivative-stats.py --prefix example curve-1.dat curve-2.dat curve-3.dat


### PR DESCRIPTION
Hi Louis,

I was using your script for estimating error across multiple replicas in my use case and I have a combined FEC as a best estimate. However, it felt like an example command was missing in your fullhelp.txt and python print statement for the fullhelp. This example template seems to work for me, let me know, if this is **not** the intended use case.